### PR TITLE
Working demo for static dispatcher

### DIFF
--- a/src/components/about/AboutPage.js
+++ b/src/components/about/AboutPage.js
@@ -1,17 +1,25 @@
-import React from "react";
+import React, { useEffect } from "react";
+import { PreferenceDemo } from "../../redux/dispatch/Demo/PreferenceDemo";
 
-const AboutPage = () => (
-  <div>
-    <h2>About</h2>
-    <p>
-      This application uses React, Redux, Redux thunk, React context provider for global data management,
-      React Router, and many other helpful libraries. In addition, we are using ThemeProvider and styled components
-      to build a theme of your choice and apply it to the rest of application on top of predefined sets of themes.
+const AboutPage = () => {
 
-      Typescript is deployed to render all queued albums related pages, so coexistence of Babel and Typescript loaders
-      is a feature of the entire application.
-    </p>
-  </div>
-);
+    useEffect(() => {
+        PreferenceDemo();
+    }, []);
+
+    return (
+        <div>
+            <h2>About</h2>
+            <p>
+                This application uses React, Redux, Redux thunk, React context provider for global data management,
+                React Router, and many other helpful libraries. In addition, we are using ThemeProvider and styled components
+                to build a theme of your choice and apply it to the rest of application on top of predefined sets of themes.
+
+                Typescript is deployed to render all queued albums related pages, so coexistence of Babel and Typescript loaders
+                is a feature of the entire application.
+            </p>
+        </div>
+    );
+};
 
 export default AboutPage;

--- a/src/redux/dispatch/Demo/PreferenceDemo.ts
+++ b/src/redux/dispatch/Demo/PreferenceDemo.ts
@@ -1,0 +1,11 @@
+import { Dispatch } from "../StaticDispatch";
+import { Colours } from "./PreferenceState";
+
+export function PreferenceDemo() {
+
+    // example: dispatch an action from anywhere!
+    Dispatch.Preference.AddMusicGenre("Jazz");
+
+    Dispatch.Preference.FavouriteColour(Colours.Blue);
+    Dispatch.Preference.FavouriteNumber(100);
+}

--- a/src/redux/dispatch/Demo/PreferenceRedux.ts
+++ b/src/redux/dispatch/Demo/PreferenceRedux.ts
@@ -1,0 +1,64 @@
+import { Colours, DefaultPreference, PreferenceState } from "./PreferenceState";
+import { DispatchBuilder } from "../DispatchBuilder";
+
+/** defines the actions and reducers for the Preference store slice */
+const builder = new DispatchBuilder<PreferenceState>("Preference", DefaultPreference);
+
+/** An object which dispatches all the preference actions */
+export const PreferenceDispatcher = {
+
+    /** Set the user's favourite colour. */
+    FavouriteColour: builder.AddAction("Favourite Colour", FavouriteColour),
+
+    /** Set the user's favourite colour. */
+    FavouriteNumber: builder.AddAction("Favourite Number", FavouriteNumber),
+
+    /** Add a new preferred music genre. */
+    AddMusicGenre: builder.AddAction("Add Music Genre", AddMusicGenre),
+
+    /** Remove the specified genre from the user's list. */
+    RemoveMusicGenre: builder.AddAction("Remove Music Genre", RemoveMusicGenre),
+};
+
+/** The reducer for the Preference state slice  */
+export const PreferenceReducer = builder.MakeReducer();
+
+/** Set the user's favourite colour. */
+function FavouriteColour(state: PreferenceState, colour: Colours): PreferenceState {
+    return {
+        ...state,
+        FavouriteColour: colour,
+    };
+}
+
+/** Set the user's favourite colour. */
+function FavouriteNumber(state: PreferenceState, number: number): PreferenceState {
+    return {
+        ...state,
+        FavouriteNumber: number,
+    };
+}
+
+/** Add a new preferred music genre. */
+function AddMusicGenre(state: PreferenceState, genre: string): PreferenceState {
+
+    // already exists
+    if (state.MusicGenres.some(i => i == genre)) return state;
+
+    // new
+    return {
+        ...state,
+        MusicGenres: [...state.MusicGenres, genre],
+    };
+}
+
+/** Remove the specified genre from the user's list. */
+function RemoveMusicGenre(state: PreferenceState, genre: string): PreferenceState {
+
+    const newGenres = state.MusicGenres.filter(i => i != genre);
+
+    return {
+        ...state,
+        MusicGenres: newGenres,
+    };
+}

--- a/src/redux/dispatch/Demo/PreferenceState.ts
+++ b/src/redux/dispatch/Demo/PreferenceState.ts
@@ -1,0 +1,29 @@
+
+/** 
+ * The user's preferences such as favourite colour.
+ * Redux state for the "Preference" slice.
+ */
+export interface PreferenceState {
+
+    /** The user's favourite colour, possibly null if one doesn't exist */
+    FavouriteColour: Colours | null;
+
+    /** Favourite number. Everyone has one! */
+    FavouriteNumber: number;
+
+    /** Music genres enjoyed by the user */
+    MusicGenres: string[];
+}
+
+export enum Colours {
+    Red,
+    Blue,
+    Green,
+}
+
+/** Default value of the Preference slice. */
+export const DefaultPreference: PreferenceState = {
+    FavouriteColour: null,
+    FavouriteNumber: 42,
+    MusicGenres: [],
+};

--- a/src/redux/dispatch/StaticDispatch.ts
+++ b/src/redux/dispatch/StaticDispatch.ts
@@ -1,18 +1,11 @@
-
-class SomethingElse {
-
-    public static y() {
-
-    }
-
-}
+import { PreferenceDispatcher } from "./Demo/PreferenceRedux";
 
 /**
  * Global access to Redux action dispatch.
  * There is one property per state slice.
  */
-export class Dispatch {
+export const Dispatch = {
 
-    public static x: SomethingElse = new SomethingElse();
-}
-
+    /** The user's preferences such as favourite colour. */
+    Preference: PreferenceDispatcher,
+};

--- a/src/redux/reducers/index.js
+++ b/src/redux/reducers/index.js
@@ -3,12 +3,14 @@ import songs from "./songReducer";
 import singers from "./singerReducer";
 import albums from "./albumReducer";
 import apiCallsInProgress from "./apiStatusReducer";
+import { PreferenceReducer } from "../dispatch/Demo/PreferenceRedux";
 
 const rootReducer = combineReducers({
   songs,
   singers,
   albums,
-  apiCallsInProgress
+  apiCallsInProgress,
+  Preference: PreferenceReducer,
 });
 
 export default rootReducer;

--- a/src/redux/reducers/initialState.js
+++ b/src/redux/reducers/initialState.js
@@ -1,6 +1,9 @@
+import { DefaultPreference } from "../dispatch/Demo/PreferenceState";
+
 export default {
   songs: [],
   singers: [],
   albums: [],
-  apiCallsInProgress: 0
+  apiCallsInProgress: 0,
+  Preference: DefaultPreference,
 };


### PR DESCRIPTION
This PR completes the static dispatch work including some demonstration code under /redux/dispatch/Demo.

A new store slice "Preference" is created, for the user's preferences. The shape is defined in `PreferenceState.ts`. 
`PreferenceRedux.ts` is where we define the action reducers and combined dispatcher object, which can create and dispatch all actions for the preference state.

`PreferenceDemo.ts` has a function showing how it is used. I made the `/about` page call this function when it is mounted.

Redux Extension in Chrome showing the new action being dispatched and updating state:
![image](https://user-images.githubusercontent.com/83536909/125183237-3a6aa880-e258-11eb-961b-afda450fe5c5.png)

