### PR TITLE
some redux typing improvements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1084,6 +1084,16 @@
       "resolved": "https://registry.npmjs.org/@types/history/-/history-4.7.8.tgz",
       "integrity": "sha512-S78QIYirQcUoo6UJZx9CSP0O2ix9IaeAXwQi26Rhr/+mg7qqPy8TzaxHSUut7eGjL8WmLccT7/MXf304WjqHcA=="
     },
+    "@types/hoist-non-react-statics": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz",
+      "integrity": "sha512-iMIqiko6ooLrTh1joXodJK5X9xeEALT1kM5G3ZLhD3hszxBdIEd5C75U834D9mLcINgD4OyZf5uQXjkuYydWvA==",
+      "dev": true,
+      "requires": {
+        "@types/react": "*",
+        "hoist-non-react-statics": "^3.3.0"
+      }
+    },
     "@types/istanbul-lib-coverage": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.0.tgz",
@@ -1153,6 +1163,18 @@
       "integrity": "sha512-ikqukEhH4H9gr4iJCmQVNzTB307kROe3XFfHAOTxOXPOw7lAoEXnM5KWTkzeANGL5Ce6ABfiMl/zJBYNi7ObmQ==",
       "requires": {
         "@types/react": "*"
+      }
+    },
+    "@types/react-redux": {
+      "version": "7.1.18",
+      "resolved": "https://registry.npmjs.org/@types/react-redux/-/react-redux-7.1.18.tgz",
+      "integrity": "sha512-9iwAsPyJ9DLTRH+OFeIrm9cAbIj1i2ANL3sKQFATqnPWRbg+jEFXyZOKHiQK/N86pNRXbb4HRxAxo0SIX1XwzQ==",
+      "dev": true,
+      "requires": {
+        "@types/hoist-non-react-statics": "^3.3.0",
+        "@types/react": "*",
+        "hoist-non-react-statics": "^3.3.0",
+        "redux": "^4.0.0"
       }
     },
     "@types/react-router": {

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
   },
   "devDependencies": {
     "@babel/core": "7.3.4",
+    "@types/react-redux": "^7.1.18",
     "babel-eslint": "10.0.1",
     "babel-loader": "8.0.5",
     "babel-preset-react-app": "7.0.2",

--- a/src/components/songs/ManageSongPage.tsx
+++ b/src/components/songs/ManageSongPage.tsx
@@ -13,15 +13,20 @@ interface IHistory {
     push: (route: string) => {}
 }
 
-interface Props {
+interface MyPropsFromStore {
     songs: ISong[];
     song: ISong;
     singers: ISinger[];
     albums: IAlbum[];
+}
+
+interface MyPropsFromJsx {
     history: IHistory;
 }
 
-export const ManageSongPage = (props: Props) => {
+type AllMyProps = MyPropsFromStore & MyPropsFromJsx;
+
+export const ManageSongPage = (props: AllMyProps) => {
     const [song, setSong] = useState({ ...props.song });
     const [errors, setErrors] = useState({});
     const [saving, setSaving] = useState(false);
@@ -93,11 +98,11 @@ export function getSongByYoutubeId(songs: ISong[], youtubeId: string) {
 interface OwnProps extends RouteComponentProps<any> {
 }
 
-function mapStateToProps(state: IRootState, ownProps: OwnProps) {
+function mapStateToProps(state: IRootState, ownProps: OwnProps): MyPropsFromStore {
     const youtubeId = ownProps.match.params.youtubeId;
     const song =
         youtubeId && state.Preference.Songs.length > 0
-            ? getSongByYoutubeId(state.Preference.Songs, youtubeId)
+            ? getSongByYoutubeId(state.Preference.Songs, youtubeId) ?? newSong
             : newSong;
     return {
         song,

--- a/src/components/songs/SongsPage.tsx
+++ b/src/components/songs/SongsPage.tsx
@@ -6,13 +6,20 @@ import Spinner from "../common/Spinner";
 import { toast } from "react-toastify";
 import { Fetch } from "../../services/useFetch"
 import * as actions from "../../redux/actions/songActions";
-import { ISong, IAlbum, IRootState } from "../../redux/dispatch/Music/PreferenceState";
+import { ISong, IAlbum, IRootState, ISinger } from "../../redux/dispatch/Music/PreferenceState";
 
 interface IState {
     redirectToAddSongPage: boolean
 }
 
-function mapStateToProps(state: IRootState) {
+interface MyPropsFromStore {
+    songs: ISong[];
+    singers: ISinger[];
+    albums: IAlbum[];
+    loading: boolean;
+}
+
+function mapStateToProps(state: IRootState): MyPropsFromStore {
     const { Singers, Albums, ApiCallsInProgress } = state.Preference;
     return {
         songs:
@@ -31,9 +38,7 @@ function mapStateToProps(state: IRootState) {
     };
 }
 
-type ReduxType = ReturnType<typeof mapStateToProps>;
-
-class SongsPage extends React.Component<ReduxType, IState> {
+class SongsPage extends React.Component<MyPropsFromStore, IState> {
     state = {
         redirectToAddSongPage: false
     };

--- a/src/redux/dispatch/Music/PreferenceState.ts
+++ b/src/redux/dispatch/Music/PreferenceState.ts
@@ -27,8 +27,8 @@ export interface ISong {
     youtubeId: string;
     singerId: number;
     albumId: number;
-    singerName: string | undefined;
-    albumName: string | undefined;
+    singerName?: string;
+    albumName?: string;
 }
 
 export interface ISinger {

--- a/tools/mockMusics.js
+++ b/tools/mockMusics.js
@@ -82,11 +82,11 @@ const albums = [
 ];
 
 const newSong = {
-  id: null,
+  id: 0,
   title: "",
-  singerId: null,
+  singerId: 0,
   youtubeId: "",
-  albumId: null,
+  albumId: 0,
 };
 
 // Using CommonJS style export so we can consume via Node (without using Babel-node)


### PR DESCRIPTION
1) react-redux typings are in a separate package, @types/react-redux. This will make your life a lot easier in your IDE, hopefully!

2) after I did this, I was able to simplify the typings in `SongsPage.tsx` quite a bit. I made an explicit type `MyPropsFromStore` to clarify this. Notice how the `MapStoreToProps` function now has an explicit return type as `MyPropsFromStore`. I find it quite helpful to do this because it will give you extra type checking and clearer errors if you forget a property.

3) I had a bit of trouble with the `newSong` object defined in a JS file. It turns out it wasn't typed properly to match ISong. It was only after adding the @types/react-redux package that VS "discovered" this. I say this is a good thing, since we have improved typing. 

4) In ManageSongPage, I have altered the props typings to make react-redux work (after it got extra TS support). The pattern I use here is very common!
a) One interface for all the props you import from the store, `MyPropsFromStore`
b) One interface for all the props you get from JSX (or elsewhere; the `history` prop ends up getting injected by React-router; it's a bit complicated).
c) Finally, a type which is the intersection of both interfaces: `type MyProps = MyPropsFromStore & MyPropsFromRedux`. 
